### PR TITLE
feat: batching ping request and running them concurently

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -5,6 +5,8 @@ password = "wow"
 dbname = "blockchains"
 
 [ping]
-batch_size = 1000
-permits = 1000
+interval = 300    # The delay between each ping round [unit: s]
+batch_size = 1000 # The number of ip address per batch
+permits = 500     # The max number of concurent task to run per batch
+timeout = 3000    # The maximum delay to wait for ping to respond [unit: ms]
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -7,6 +7,6 @@ dbname = "blockchains"
 [ping]
 interval = 300    # The delay between each ping round [unit: s]
 batch_size = 1000 # The number of ip address per batch
-permits = 500     # The max number of concurent task to run per batch
+task_limit = 500  # The max number of concurent task to run per batch
 timeout = 3000    # The maximum delay to wait for ping to respond [unit: ms]
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -3,3 +3,8 @@ host = "localhost"
 user = "postgres"
 password = "wow"
 dbname = "blockchains"
+
+[ping]
+batch_size = 1000
+permits = 1000
+

--- a/src/bin/ping.rs
+++ b/src/bin/ping.rs
@@ -10,6 +10,107 @@ use tokio_postgres::Transaction;
 
 use void::config;
 
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Init logger
+    env_logger::init();
+
+    info!("Starting ping");
+
+    let cfg = config::read_config();
+
+    // Connect to postgres
+    let database_params = format!(
+        "host={} user={} password={} dbname={}",
+        cfg.database.host, cfg.database.user, cfg.database.password, cfg.database.dbname,
+    );
+    let (mut client, connection) = tokio_postgres::connect(&database_params, NoTls).await?;
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            error!("Connection error: {}", e);
+        }
+    });
+
+    // Loading ping config
+    let timeout_duration = Duration::from_millis(cfg.ping.timeout);
+    let semaphore = Arc::new(Semaphore::new(cfg.ping.permits));
+    let batch_size = cfg.ping.batch_size;
+    let interval = Duration::from_secs(cfg.ping.interval);
+
+    let mut round_id = 0;
+    // Starts infinite loop
+    loop {
+        ping_round(&mut client, &semaphore, batch_size, timeout_duration).await?;
+        info!(
+            "Round {} finished. Waiting for {} seconds before the next round...",
+            round_id,
+            interval.as_secs()
+        );
+        sleep(interval).await;
+        round_id += 1;
+    }
+}
+
+// Runs batches of concurent ping requests against db ip addresses
+// and update last_ping_timestamp to NOW() for each successful requests
+async fn ping_round(
+    client: &mut tokio_postgres::Client,
+    semaphore: &Arc<Semaphore>,
+    batch_size: i64,
+    timeout_duration: Duration,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut offset = 0;
+    loop {
+        let transaction = client.transaction().await?;
+        let rows = fetch_batch(&transaction, offset, batch_size).await?;
+        if rows.is_empty() {
+            break;
+        }
+        let updates = ping_batch(&rows, semaphore, timeout_duration).await?;
+        update_batch(&transaction, updates).await?;
+        transaction.commit().await?;
+        offset += batch_size;
+    }
+    Ok(())
+}
+
+async fn ping_batch(
+    rows: &[tokio_postgres::Row],
+    semaphore: &Arc<Semaphore>,
+    timeout_duration: Duration,
+) -> Result<Vec<(String, i32)>, Box<dyn std::error::Error>> {
+    let mut tasks = Vec::new();
+    for row in rows {
+        let address: String = row.get(0);
+        let tcp_port: i32 = row.get(1);
+        let semaphore = Arc::clone(&semaphore);
+
+        tasks.push(tokio::spawn(async move {
+            let _permit = semaphore.acquire().await.unwrap(); // Wait for a permit
+            let socket_address: SocketAddr = format!("{}:{}", address, tcp_port).parse().unwrap();
+
+            match timeout(timeout_duration, TcpStream::connect(&socket_address)).await {
+                Ok(Ok(_)) => {
+                    info!("{} on port {} is working", address, tcp_port);
+                    Some((address, tcp_port))
+                }
+                Ok(Err(_)) | Err(_) => {
+                    error!("{} on port {} is NOT WORKING...", address, tcp_port);
+                    None
+                }
+            }
+        }));
+    }
+    let mut updates = Vec::new();
+    for task in tasks {
+        if let Some(update) = task.await? {
+            updates.push(update);
+        }
+    }
+
+    Ok(updates)
+}
+
 async fn fetch_batch(
     transaction: &tokio_postgres::Transaction<'_>,
     offset: i64,
@@ -24,7 +125,7 @@ async fn fetch_batch(
     Ok(rows)
 }
 
-async fn batch_update(
+async fn update_batch(
     transaction: &Transaction<'_>,
     updates: Vec<(String, i32)>,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -37,91 +138,4 @@ async fn batch_update(
             .await?;
     }
     Ok(())
-}
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // init logger
-    env_logger::init();
-
-    info!("Starting ping");
-
-    let cfg = config::read_config();
-
-    // Connect to postgres
-    let database_params = format!(
-        "host={} user={} password={} dbname={}",
-        cfg.database.host, cfg.database.user, cfg.database.password, cfg.database.dbname,
-    );
-
-    let (mut client, connection) = tokio_postgres::connect(&database_params, NoTls).await?;
-
-    tokio::spawn(async move {
-        if let Err(e) = connection.await {
-            error!("Connection error: {}", e);
-        }
-    });
-
-    // Loading ping config
-    let timeout_duration = Duration::from_millis(cfg.ping.timeout);
-    let semaphore = Arc::new(Semaphore::new(cfg.ping.permits));
-    let batch_size = cfg.ping.batch_size;
-    let interval = Duration::from_secs(cfg.ping.interval);
-
-    let mut round_id = 0;
-
-    loop {
-        let mut offset = 0;
-        loop {
-            let transaction = client.transaction().await?;
-            let rows = fetch_batch(&transaction, offset, batch_size).await?;
-            if rows.is_empty() {
-                break;
-            }
-
-            let mut tasks = Vec::new();
-            for row in rows {
-                let address: String = row.get(0);
-                let tcp_port: i32 = row.get(1);
-                let semaphore = Arc::clone(&semaphore);
-
-                tasks.push(tokio::spawn(async move {
-                    let _permit = semaphore.acquire().await.unwrap(); // Wait for a permit
-                    let socket_address: SocketAddr =
-                        format!("{}:{}", address, tcp_port).parse().unwrap();
-
-                    match timeout(timeout_duration, TcpStream::connect(&socket_address)).await {
-                        Ok(Ok(_)) => {
-                            info!("{} on port {} is working", address, tcp_port);
-                            Some((address, tcp_port))
-                        }
-                        Ok(Err(_)) | Err(_) => {
-                            error!("{} on port {} is NOT WORKING...", address, tcp_port);
-                            None
-                        }
-                    }
-                }));
-            }
-            let mut updates = Vec::new();
-            for task in tasks {
-                if let Some(update) = task.await? {
-                    updates.push(update);
-                }
-            }
-
-            batch_update(&transaction, updates).await?;
-            transaction.commit().await?;
-
-            offset += batch_size;
-        }
-        if offset > 0 {
-            info!(
-                "Round {} finished. Waiting for {} seconds before the next batch...",
-                round_id,
-                interval.as_secs()
-            );
-            sleep(interval).await;
-        }
-        round_id += 1;
-    }
 }

--- a/src/bin/ping.rs
+++ b/src/bin/ping.rs
@@ -1,4 +1,4 @@
-use log::info;
+use log::{error, info};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::net::TcpStream;
@@ -58,7 +58,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     tokio::spawn(async move {
         if let Err(e) = connection.await {
-            eprintln!("Connection error: {}", e);
+            error!("Connection error: {}", e);
         }
     });
 
@@ -87,11 +87,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                 match timeout(timeout_duration, TcpStream::connect(&socket_address)).await {
                     Ok(Ok(_)) => {
-                        println!("{} on port {} is working", address, tcp_port);
+                        info!("{} on port {} is working", address, tcp_port);
                         Some((address, tcp_port))
                     }
                     Ok(Err(_)) | Err(_) => {
-                        println!("{} on port {} is NOT WORKING...", address, tcp_port);
+                        error!("{} on port {} is NOT WORKING...", address, tcp_port);
                         None
                     }
                 }

--- a/src/bin/ping.rs
+++ b/src/bin/ping.rs
@@ -33,7 +33,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Loading ping config
     let timeout_duration = Duration::from_millis(cfg.ping.timeout);
-    let semaphore = Arc::new(Semaphore::new(cfg.ping.permits));
+    let semaphore = Arc::new(Semaphore::new(cfg.ping.task_limit));
     let batch_size = cfg.ping.batch_size;
     let interval = Duration::from_secs(cfg.ping.interval);
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,8 +12,15 @@ pub struct DatabaseConfig {
 }
 
 #[derive(Debug, Deserialize)]
+pub struct PingConfig {
+    pub batch_size: i64,
+    pub permits: usize,
+}
+
+#[derive(Debug, Deserialize)]
 pub struct Config {
     pub database: DatabaseConfig,
+    pub ping: PingConfig,
 }
 
 pub fn read_config() -> Config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,7 @@ pub struct DatabaseConfig {
 #[derive(Debug, Deserialize)]
 pub struct PingConfig {
     pub batch_size: i64,
-    pub permits: usize,
+    pub task_limit: usize,
     pub timeout: u64,
     pub interval: u64,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,8 @@ pub struct DatabaseConfig {
 pub struct PingConfig {
     pub batch_size: i64,
     pub permits: usize,
+    pub timeout: u64,
+    pub interval: u64,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
This is a proposition to run ping requests concurrently, I can update ~4k entries in the db in about ~20sc with `batch_size = 1000` and `permits = 1000`.

Further benchmarks may be needed to better understand what are the bottlenecks of this approach. 

Also, maybe the whole approach is wrong, please let me know if you think so :)