### PR TITLE
fix: properly create header so Nethermind won't reject us

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -411,6 +411,9 @@ pub fn create_header(
     BigEndian::write_uint(&mut buf, length as u64, 3);
     let mut header = [0_u8; 16];
     header[0..3].copy_from_slice(&buf[0..3]);
+    header[3] = 0xC2;
+    header[4] = 0x80;
+    header[5] = 0x80;
 
     egress_aes.apply_keystream(&mut header);
     egress_mac.update_header(&mut header.to_vec());


### PR DESCRIPTION
Even if don't put sequence id in the header it needs to be properly rlp encoded otherwise some Ethereum implementation are ditching us.

closes #19 